### PR TITLE
Update version to 0.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ It is entirely possible to write one's own CTI wrapper, but `pycti-arbin` provid
 
 ## Installation
 
+### Using pip
+
+`pycti-arbin` can be installed using pip:
+
+```bash
+pip install pycti-arbin
+```
+
 ### Source Installation
 
 To install from source, type the following into the command line:
@@ -83,7 +91,7 @@ Where the fields are as follows:
 - `ip_address` : str
     The IP address of the Arbin host computer.
 - `port` : int
-    The TCP port to communicate through. This is generally going to be 7031
+    The TCP port to communicate through. This is generally going to be 9031
 - `timeout_s` : *optional* : float
     How long to wait before timing out on TCP communication. Defaults to 3 seconds.
 - `msg_buffer_size` : *optional* : int
@@ -176,6 +184,13 @@ channel_interface.read_channel_status()
 
 For more examples of how to use the `CyclerInterface` and `ChannelInterface` class see the `demo_notebook.ipynb` and documentation.
 
+## Tested MITS Pro Version
+
+| Version         | Build      | pycti-arbin |
+|-----------------|------------|-------------|
+| Mits8 PV.202110 | Oct 4 2021 | 0.0.4       |
+|                 |            |             |
+
 ## Development
 
 This section contains various information to help developers further extend and test `pycti-arbin`
@@ -215,7 +230,7 @@ Testing software on a real cycler is dangerous so we've created a submodule `arb
 All documentation was generated with [pydoc](https://docs.python.org/3/library/pydoc.html). To re-generate the documentation type the following command from the top level directory of the repository:
 
 ```bash
-pdoc --html .
+pydoc --html .
 ```
 
 ## License

--- a/pyctiarbin/messages.py
+++ b/pyctiarbin/messages.py
@@ -73,8 +73,13 @@ class MessageABC(ABC):
 
             # Decode and strip trailing 0x00s from strings.
             if item['format'].endswith('s'):
-                decoded_msg_dict[item_name] = decoded_msg_dict[item_name].decode(
-                    item['text_encoding']).rstrip('\x00')
+                # ignore utf-8 characters that cannot be decoded
+                if item['text_encoding'] == 'utf-8':
+                    decoded_msg_dict[item_name] = decoded_msg_dict[item_name].decode(
+                        item['text_encoding'], errors='ignore').rstrip('\x00')
+                else:
+                    decoded_msg_dict[item_name] = decoded_msg_dict[item_name].decode(
+                        item['text_encoding']).rstrip('\x00')
 
         if decoded_msg_dict['command_code'] != cls.command_code:
             logger.warning(

--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,9 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="pycti-arbin",
-    version="0.0.3",
-    author="Zander Nevitt",
-    author_email="zandern@battgenie.life",
+    version="0.0.4",
+    author="Zander Nevitt, Bing Syuan Wang",
+    author_email="info@battgenie.life",
     description="A class based Python interface for communication and control of Arbin cyclers over CTI.",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
- Add pip installation to README
- Add MITS Pro tested version. Closes #1 
- Ignore errors when decoding UTF-8 that exceed the encoding limit